### PR TITLE
Refactor: OrdersService composition cleanup (controllers + extensions)

### DIFF
--- a/backend/src/SseDemo.OrdersService/Controllers/OrdersController.cs
+++ b/backend/src/SseDemo.OrdersService/Controllers/OrdersController.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Mvc;
+using SseDemo.Domain.Abstractions;
+using SseDemo.Domain.Entities;
+using SseDemo.OrdersService.Dtos;
+using SseDemo.OrdersService.Sse;
+
+namespace SseDemo.OrdersService.Controllers;
+
+/// <summary>
+/// Order operations (create, list, get, status transitions)
+/// </summary>
+[ApiController]
+[Route("api/[controller]")] // api/orders
+public class OrdersController : ControllerBase
+{
+    private readonly IOrderRepository _repo;
+    private readonly IOrderEventPublisher _publisher;
+    private readonly ILogger<OrdersController> _logger;
+
+    public OrdersController(IOrderRepository repo, IOrderEventPublisher publisher, ILogger<OrdersController> logger)
+    {
+        _repo = repo;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(OrderResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create([FromBody] CreateOrderRequest req, CancellationToken ct)
+    {
+        var errors = new Dictionary<string, string>();
+        if (string.IsNullOrWhiteSpace(req.CustomerName)) errors["customerName"] = "Required";
+        if (req.TotalAmount is null || req.TotalAmount < 0) errors["totalAmount"] = "Must be >= 0";
+        if (errors.Count > 0) return BadRequest(new ErrorResponse("validation_error", "Validation failed", errors));
+
+        var order = Order.Create(req.CustomerName!.Trim(), req.TotalAmount!.Value);
+        await _repo.AddAsync(order, ct);
+        _logger.LogInformation("Order created {OrderId} code={Code} amount={Amount}", order.Id, order.Code, order.TotalAmount);
+        await _publisher.OrderCreatedAsync(order, ct);
+        var response = OrderResponse.From(order);
+        return Created($"/api/orders/{order.Id}", response);
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ListOrdersResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> List(CancellationToken ct)
+    {
+        var list = await _repo.ListAsync(0, 200, ct);
+        var items = list.Select(OrderResponse.From).ToArray();
+        return Ok(new ListOrdersResponse { Items = items, Total = items.Length });
+    }
+
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(OrderResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get(Guid id, CancellationToken ct)
+    {
+        var order = await _repo.GetAsync(id, ct);
+        if (order == null) return NotFound(new ErrorResponse("not_found", "Order not found"));
+        return Ok(OrderResponse.From(order));
+    }
+
+    [HttpPost("{id:guid}/pay")]
+    [ProducesResponseType(typeof(OrderResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Pay(Guid id, CancellationToken ct)
+    {
+        var order = await _repo.GetAsync(id, ct);
+        if (order == null) return NotFound(new ErrorResponse("not_found", "Order not found"));
+        var prev = order.Status.ToString();
+        if (!order.MarkPaid()) return BadRequest(new ErrorResponse("invalid_state", "Cannot mark as paid from current state"));
+        await _repo.UpdateAsync(order, ct);
+        _logger.LogInformation("Order paid {OrderId} prev={Prev} new={New}", order.Id, prev, order.Status);
+        await _publisher.OrderStatusChangedAsync(order, prev, ct);
+        return Ok(OrderResponse.From(order));
+    }
+
+    [HttpPost("{id:guid}/fulfill")]
+    [ProducesResponseType(typeof(OrderResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Fulfill(Guid id, CancellationToken ct)
+    {
+        var order = await _repo.GetAsync(id, ct);
+        if (order == null) return NotFound(new ErrorResponse("not_found", "Order not found"));
+        var prev = order.Status.ToString();
+        if (!order.MarkFulfilled()) return BadRequest(new ErrorResponse("invalid_state", "Cannot fulfill from current state"));
+        await _repo.UpdateAsync(order, ct);
+        _logger.LogInformation("Order fulfilled {OrderId} prev={Prev} new={New}", order.Id, prev, order.Status);
+        await _publisher.OrderStatusChangedAsync(order, prev, ct);
+        return Ok(OrderResponse.From(order));
+    }
+
+    [HttpPost("{id:guid}/cancel")]
+    [ProducesResponseType(typeof(OrderResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Cancel(Guid id, CancellationToken ct)
+    {
+        var order = await _repo.GetAsync(id, ct);
+        if (order == null) return NotFound(new ErrorResponse("not_found", "Order not found"));
+        var prev = order.Status.ToString();
+        if (!order.Cancel()) return BadRequest(new ErrorResponse("invalid_state", "Cannot cancel from current state"));
+        await _repo.UpdateAsync(order, ct);
+        _logger.LogInformation("Order canceled {OrderId} prev={Prev} new={New}", order.Id, prev, order.Status);
+        await _publisher.OrderStatusChangedAsync(order, prev, ct);
+        return Ok(OrderResponse.From(order));
+    }
+}

--- a/backend/src/SseDemo.OrdersService/Controllers/SseController.cs
+++ b/backend/src/SseDemo.OrdersService/Controllers/SseController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+using SseDemo.OrdersService.Sse;
+
+namespace SseDemo.OrdersService.Controllers;
+
+/// <summary>
+/// SSE streaming and diagnostics
+/// </summary>
+[ApiController]
+[Route("sse")]
+public class SseController : ControllerBase
+{
+    private readonly ISseClientRegistry _registry;
+    private readonly ILogger<SseController> _logger;
+
+    public SseController(ISseClientRegistry registry, ILogger<SseController> logger)
+    {
+        _registry = registry;
+        _logger = logger;
+    }
+
+    [HttpGet("stream")]
+    public async Task Stream(CancellationToken ct)
+    {
+        Response.Headers["Content-Type"] = "text/event-stream";
+        Response.Headers["Cache-Control"] = "no-cache";
+        Response.Headers["Connection"] = "keep-alive";
+        var id = _registry.Register(Response, ct);
+        await Response.WriteAsync(": connected \n\n");
+        await Response.Body.FlushAsync(ct);
+        try { await Task.Delay(Timeout.Infinite, ct); }
+        catch (TaskCanceledException) { }
+        finally { _registry.Remove(id); }
+    }
+
+    [HttpGet("clients")]
+    [ProducesResponseType(typeof(SseClientsSnapshot), StatusCodes.Status200OK)]
+    public ActionResult<SseClientsSnapshot> Clients() => Ok(_registry.GetSnapshot());
+}

--- a/backend/src/SseDemo.OrdersService/Controllers/SystemController.cs
+++ b/backend/src/SseDemo.OrdersService/Controllers/SystemController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SseDemo.OrdersService.Controllers;
+
+/// <summary>
+/// System / utility endpoints
+/// </summary>
+[ApiController]
+[Route("")]
+public class SystemController : ControllerBase
+{
+    [HttpGet("ping")]
+    public IActionResult Ping() => Ok(new { ok = true, service = "orders", ts = DateTimeOffset.UtcNow });
+}

--- a/backend/src/SseDemo.OrdersService/Extensions/CorrelationExtensions.cs
+++ b/backend/src/SseDemo.OrdersService/Extensions/CorrelationExtensions.cs
@@ -1,0 +1,30 @@
+using Serilog.Context;
+using System.Diagnostics;
+using SseDemo.OrdersService.Tracing;
+
+namespace SseDemo.OrdersService.Extensions;
+
+public static class CorrelationExtensions
+{
+    private const string TraceHeader = "x-trace-id";
+
+    public static IApplicationBuilder UseTraceCorrelation(this IApplicationBuilder app)
+    {
+        app.Use(async (ctx, next) =>
+        {
+            if (!ctx.Request.Headers.TryGetValue(TraceHeader, out var traceId) || string.IsNullOrWhiteSpace(traceId))
+            {
+                traceId = Activity.Current?.TraceId.ToString() ?? Guid.NewGuid().ToString("n");
+                ctx.Request.Headers[TraceHeader] = traceId;
+            }
+            ctx.Response.Headers[TraceHeader] = traceId!;
+            var accessor = ctx.RequestServices.GetRequiredService<ITraceContextAccessor>();
+            accessor.TraceId = traceId!;
+            using (LogContext.PushProperty("TraceId", traceId!))
+            {
+                await next();
+            }
+        });
+        return app;
+    }
+}

--- a/backend/src/SseDemo.OrdersService/Extensions/HealthExtensions.cs
+++ b/backend/src/SseDemo.OrdersService/Extensions/HealthExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace SseDemo.OrdersService.Extensions;
+
+public static class HealthExtensions
+{
+    public static IServiceCollection AddAppHealthChecks(this IServiceCollection services)
+    {
+        services.AddHealthChecks()
+            .AddCheck<SseDemo.OrdersService.Health.SseRegistryHealthCheck>("sse_registry")
+            .AddCheck<SseDemo.OrdersService.Health.OrderRepositoryHealthCheck>("orders_repository");
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapAppHealth(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapHealthChecks("/health");
+        endpoints.MapHealthChecks("/ready", new HealthCheckOptions
+        {
+            Predicate = _ => true,
+            ResponseWriter = async (ctx, report) =>
+            {
+                ctx.Response.ContentType = "application/json";
+                var payload = System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    status = report.Status.ToString().ToLowerInvariant(),
+                    checks = report.Entries.Select(e => new { name = e.Key, status = e.Value.Status.ToString().ToLowerInvariant(), data = e.Value.Data })
+                });
+                await ctx.Response.WriteAsync(payload);
+            }
+        });
+        return endpoints;
+    }
+}

--- a/backend/src/SseDemo.OrdersService/Extensions/LoggingExtensions.cs
+++ b/backend/src/SseDemo.OrdersService/Extensions/LoggingExtensions.cs
@@ -1,0 +1,18 @@
+using Serilog;
+
+namespace SseDemo.OrdersService.Extensions;
+
+public static class LoggingExtensions
+{
+    /// <summary>
+    /// Configure Serilog for the host using configuration (appsettings etc.).
+    /// </summary>
+    public static IHostBuilder UseSerilogLogging(this IHostBuilder hostBuilder, IConfiguration configuration)
+    {
+        hostBuilder.UseSerilog((ctx, cfg) => cfg
+            .ReadFrom.Configuration(configuration)
+            .Enrich.FromLogContext()
+            .WriteTo.Console());
+        return hostBuilder;
+    }
+}

--- a/backend/src/SseDemo.OrdersService/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/SseDemo.OrdersService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using SseDemo.Domain.Abstractions;
+using SseDemo.OrdersService.Repositories;
+using SseDemo.OrdersService.Sse;
+using SseDemo.OrdersService.Tracing;
+
+namespace SseDemo.OrdersService.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register application core services (controllers, swagger, health, repositories, SSE infra, tracing).
+    /// </summary>
+    public static IServiceCollection AddAppServices(this IServiceCollection services)
+    {
+        services.AddControllers();
+        services.AddEndpointsApiExplorer();
+        services.AddAppSwagger();
+        services.AddAppHealthChecks();
+
+        // Domain / data
+        services.AddSingleton<IOrderRepository, InMemoryOrderRepository>();
+
+        // SSE infrastructure
+        services.AddSingleton<ISseClientRegistry, InMemorySseClientRegistry>();
+        services.AddSingleton<IOrderEventPublisher, SseOrderEventPublisher>();
+        services.AddHostedService<SseHeartbeatService>();
+
+        // Tracing accessor
+        services.AddSingleton<ITraceContextAccessor, TraceContextAccessor>();
+
+        return services;
+    }
+}

--- a/backend/src/SseDemo.OrdersService/Extensions/SwaggerExtensions.cs
+++ b/backend/src/SseDemo.OrdersService/Extensions/SwaggerExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.OpenApi.Models;
+
+namespace SseDemo.OrdersService.Extensions;
+
+public static class SwaggerExtensions
+{
+    public static IServiceCollection AddAppSwagger(this IServiceCollection services)
+    {
+        services.AddSwaggerGen(o =>
+        {
+            o.SwaggerDoc("v1", new OpenApiInfo
+            {
+                Title = "Orders Service API",
+                Version = "v1",
+                Description = "API de pedidos com SSE broadcast de eventos (order-created, order-status-changed)"
+            });
+            o.OperationFilter<SseDemo.OrdersService.OpenApi.TraceIdHeaderOperationFilter>();
+            o.SchemaFilter<SseDemo.OrdersService.OpenApi.OrderResponseExample>();
+            o.SchemaFilter<SseDemo.OrdersService.OpenApi.ErrorResponseExample>();
+        });
+        return services;
+    }
+
+    public static IApplicationBuilder UseAppSwagger(this IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
+        {
+            app.UseSwagger();
+            app.UseSwaggerUI(c =>
+            {
+                c.RoutePrefix = string.Empty;
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Orders Service API v1");
+                c.DocumentTitle = "Orders Service API";
+            });
+        }
+        return app;
+    }
+}

--- a/backend/src/SseDemo.OrdersService/Program.cs
+++ b/backend/src/SseDemo.OrdersService/Program.cs
@@ -1,191 +1,23 @@
 using Serilog;
-using Serilog.Context;
-using SseDemo.Domain.Abstractions;
-using SseDemo.Domain.Entities;
-using SseDemo.OrdersService.Dtos;
-using SseDemo.OrdersService.Sse;
-using System.Diagnostics;
-using SseDemo.OrdersService.Tracing;
+using SseDemo.OrdersService.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Serilog basic configuration (will evolve for enrichment later)
-builder.Host.UseSerilog((ctx, cfg) => cfg
-    .ReadFrom.Configuration(ctx.Configuration)
-    .Enrich.FromLogContext()
-    .WriteTo.Console());
+// Logging configuration
+builder.Host.UseSerilogLogging(builder.Configuration);
 
-// Services
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(o =>
-{
-    o.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
-    {
-        Title = "Orders Service API",
-        Version = "v1",
-        Description = "API de pedidos com SSE broadcast de eventos (order-created, order-status-changed)"
-    });
-    o.OperationFilter<SseDemo.OrdersService.OpenApi.TraceIdHeaderOperationFilter>();
-    o.SchemaFilter<SseDemo.OrdersService.OpenApi.OrderResponseExample>();
-    o.SchemaFilter<SseDemo.OrdersService.OpenApi.ErrorResponseExample>();
-});
-builder.Services.AddHealthChecks()
-    .AddCheck<SseDemo.OrdersService.Health.SseRegistryHealthCheck>("sse_registry")
-    .AddCheck<SseDemo.OrdersService.Health.OrderRepositoryHealthCheck>("orders_repository");
-
-// Repositories
-builder.Services.AddSingleton<SseDemo.Domain.Abstractions.IOrderRepository, SseDemo.OrdersService.Repositories.InMemoryOrderRepository>();
-// SSE registry
-builder.Services.AddSingleton<ISseClientRegistry, InMemorySseClientRegistry>();
-builder.Services.AddSingleton<IOrderEventPublisher, SseOrderEventPublisher>();
-builder.Services.AddHostedService<SseHeartbeatService>();
-builder.Services.AddSingleton<ITraceContextAccessor, TraceContextAccessor>();
+// Application services registration
+builder.Services.AddAppServices();
 
 var app = builder.Build();
 
 // Middleware pipeline
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(c =>
-    {
-        c.RoutePrefix = string.Empty; // serve Swagger UI at root '/'
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "Orders Service API v1");
-        c.DocumentTitle = "Orders Service API";
-    });
-}
+app.UseAppSwagger(app.Environment);
 
 app.UseSerilogRequestLogging();
-// Correlation / TraceId middleware
-app.Use(async (ctx, next) =>
-{
-    const string TraceHeader = "x-trace-id";
-    if (!ctx.Request.Headers.TryGetValue(TraceHeader, out var traceId) || string.IsNullOrWhiteSpace(traceId))
-    {
-        traceId = Activity.Current?.TraceId.ToString() ?? Guid.NewGuid().ToString("n");
-        ctx.Request.Headers[TraceHeader] = traceId;
-    }
-    ctx.Response.Headers[TraceHeader] = traceId!;
-    var accessor = ctx.RequestServices.GetRequiredService<ITraceContextAccessor>();
-    accessor.TraceId = traceId!;
-    using (LogContext.PushProperty("TraceId", traceId!))
-    {
-        await next();
-    }
-});
-app.MapHealthChecks("/health"); // liveness (process up)
-app.MapHealthChecks("/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
-{
-    Predicate = _ => true,
-    ResponseWriter = async (ctx, report) =>
-    {
-        ctx.Response.ContentType = "application/json";
-        var payload = System.Text.Json.JsonSerializer.Serialize(new
-        {
-            status = report.Status.ToString().ToLowerInvariant(),
-            checks = report.Entries.Select(e => new { name = e.Key, status = e.Value.Status.ToString().ToLowerInvariant(), data = e.Value.Data })
-        });
-        await ctx.Response.WriteAsync(payload);
-    }
-});
+app.UseTraceCorrelation();
+app.MapAppHealth();
 
-app.MapGet("/ping", () => Results.Ok(new { ok = true, service = "orders", ts = DateTimeOffset.UtcNow }));
-
-var orders = app.MapGroup("/api/orders").WithTags("Orders");
-// SSE streaming endpoint
-app.MapGet("/sse/stream", async (HttpContext ctx, ISseClientRegistry registry) =>
-{
-    ctx.Response.Headers["Content-Type"] = "text/event-stream";
-    ctx.Response.Headers["Cache-Control"] = "no-cache";
-    ctx.Response.Headers["Connection"] = "keep-alive";
-    var id = registry.Register(ctx.Response, ctx.RequestAborted);
-    // Initial comment to keep connection open
-    await ctx.Response.WriteAsync(": connected \n\n");
-    await ctx.Response.Body.FlushAsync();
-    // Hold until client disconnect
-    try { await Task.Delay(Timeout.Infinite, ctx.RequestAborted); }
-    catch (TaskCanceledException) { }
-    finally { registry.Remove(id); }
-}).WithOpenApi(op => { op.Summary = "Fluxo SSE de eventos"; return op; });
-
-// SSE clients snapshot (diagnóstico simples)
-app.MapGet("/sse/clients", (ISseClientRegistry registry) => Results.Ok(registry.GetSnapshot()))
-    .WithOpenApi(op => { op.Summary = "Snapshot conexões SSE"; return op; });
-
-orders.MapPost("/", async (CreateOrderRequest req, IOrderRepository repo, IOrderEventPublisher publisher, HttpContext http, CancellationToken ct, ILoggerFactory loggerFactory) =>
-{
-    var logger = loggerFactory.CreateLogger("Orders.Create");
-    // Basic validation (simplified; could use FluentValidation later)
-    var errors = new Dictionary<string, string>();
-    if (string.IsNullOrWhiteSpace(req.CustomerName)) errors["customerName"] = "Required";
-    if (req.TotalAmount is null || req.TotalAmount < 0) errors["totalAmount"] = "Must be >= 0";
-    if (errors.Count > 0)
-        return Results.BadRequest(new ErrorResponse("validation_error", "Validation failed", errors));
-
-    var order = Order.Create(req.CustomerName!.Trim(), req.TotalAmount!.Value);
-    await repo.AddAsync(order);
-    logger.LogInformation("Order created {OrderId} code={Code} amount={Amount}", order.Id, order.Code, order.TotalAmount);
-    // publish SSE event (fire & forget pattern acceptable here, but await to surface errors early)
-    await publisher.OrderCreatedAsync(order, ct);
-    var response = OrderResponse.From(order);
-    var location = $"/api/orders/{order.Id}";
-    return Results.Created(location, response);
-})
-.WithOpenApi(op => { op.Summary = "Cria um novo pedido"; return op; });
-
-orders.MapGet("/", async (IOrderRepository repo) =>
-{
-    var list = await repo.ListAsync(0, 200);
-    var items = list.Select(OrderResponse.From).ToArray();
-    return Results.Ok(new ListOrdersResponse { Items = items, Total = items.Length });
-})
-.WithOpenApi(op => { op.Summary = "Lista pedidos"; return op; });
-
-orders.MapGet("/{id:guid}", async (Guid id, IOrderRepository repo) =>
-{
-    var order = await repo.GetAsync(id);
-    if (order == null) return Results.NotFound(new ErrorResponse("not_found", "Order not found"));
-    return Results.Ok(OrderResponse.From(order));
-})
-.WithOpenApi(op => { op.Summary = "Obtém pedido por ID"; return op; });
-
-orders.MapPost("/{id:guid}/pay", async (Guid id, IOrderRepository repo, IOrderEventPublisher publisher, CancellationToken ct, ILoggerFactory lf) =>
-{
-    var logger = lf.CreateLogger("Orders.Pay");
-    var order = await repo.GetAsync(id);
-    if (order == null) return Results.NotFound(new ErrorResponse("not_found", "Order not found"));
-    var prev = order.Status.ToString();
-    if (!order.MarkPaid()) return Results.BadRequest(new ErrorResponse("invalid_state", "Cannot mark as paid from current state"));
-    await repo.UpdateAsync(order);
-    logger.LogInformation("Order paid {OrderId} prev={Prev} new={New}", order.Id, prev, order.Status);
-    await publisher.OrderStatusChangedAsync(order, prev, ct);
-    return Results.Ok(OrderResponse.From(order));
-}).WithOpenApi(op => { op.Summary = "Marca pedido como pago"; return op; });
-
-orders.MapPost("/{id:guid}/fulfill", async (Guid id, IOrderRepository repo, IOrderEventPublisher publisher, CancellationToken ct, ILoggerFactory lf) =>
-{
-    var logger = lf.CreateLogger("Orders.Fulfill");
-    var order = await repo.GetAsync(id);
-    if (order == null) return Results.NotFound(new ErrorResponse("not_found", "Order not found"));
-    var prev = order.Status.ToString();
-    if (!order.MarkFulfilled()) return Results.BadRequest(new ErrorResponse("invalid_state", "Cannot fulfill from current state"));
-    await repo.UpdateAsync(order);
-    logger.LogInformation("Order fulfilled {OrderId} prev={Prev} new={New}", order.Id, prev, order.Status);
-    await publisher.OrderStatusChangedAsync(order, prev, ct);
-    return Results.Ok(OrderResponse.From(order));
-}).WithOpenApi(op => { op.Summary = "Marca pedido como finalizado"; return op; });
-
-orders.MapPost("/{id:guid}/cancel", async (Guid id, IOrderRepository repo, IOrderEventPublisher publisher, CancellationToken ct, ILoggerFactory lf) =>
-{
-    var logger = lf.CreateLogger("Orders.Cancel");
-    var order = await repo.GetAsync(id);
-    if (order == null) return Results.NotFound(new ErrorResponse("not_found", "Order not found"));
-    var prev = order.Status.ToString();
-    if (!order.Cancel()) return Results.BadRequest(new ErrorResponse("invalid_state", "Cannot cancel from current state"));
-    await repo.UpdateAsync(order);
-    logger.LogInformation("Order canceled {OrderId} prev={Prev} new={New}", order.Id, prev, order.Status);
-    await publisher.OrderStatusChangedAsync(order, prev, ct);
-    return Results.Ok(OrderResponse.From(order));
-}).WithOpenApi(op => { op.Summary = "Cancela pedido"; return op; });
+app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
### Summary
Refactored OrdersService to improve maintainability and separation of concerns.

### Changes
- Extracted all minimal API endpoints into MVC Controllers (`OrdersController`, `SseController`, `SystemController`).
- Added extension classes:
  - `LoggingExtensions` (Serilog host configuration)
  - `SwaggerExtensions` (Add/Use swagger)
  - `HealthExtensions` (health & readiness registration + mapping)
  - `CorrelationExtensions` (trace correlation middleware)
  - `ServiceCollectionExtensions` (aggregated service registrations: controllers, swagger, health, repositories, SSE infra, tracing)
- Simplified `Program.cs` to a concise composition root calling the extensions.
- Preserved existing functionality (ping, orders CRUD/state transitions, SSE streaming, health checks, swagger at root, trace header).

### Motivation
Reduces clutter in `Program.cs`, enforces SRP, and sets a cleaner foundation before starting frontend integration tasks.

### Impact
No breaking API changes. Routes and behaviors unchanged.

### Test / Validation
- Local build succeeds (`dotnet build`).
- Smoke tests: `/ping`, `/health`, `/ready`, root swagger, and `x-trace-id` header validated.

### Next Steps
Proceed with frontend Task 3.1 (Angular project setup) after merge.

---
Let me know if any additional adjustments are desired.